### PR TITLE
[#26] bug:route 주소 /mapSearch로 변경, Menubar에서 선택 시 지도 띄워지도록

### DIFF
--- a/src/component/Menubar.js
+++ b/src/component/Menubar.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react'
+import React, {useEffect, useState} from 'react'
 import styled from "styled-components"
 import {Icon} from 'semantic-ui-react'
 import { useHistory, Link } from "react-router-dom";
@@ -8,7 +8,6 @@ const Wrap = styled.div`
   max-width: 640px;
   margin: 0px auto;
   padding-bottom: 0px;
-  
 `
 const TopMenu = styled.div`
   display: flex;
@@ -64,6 +63,14 @@ function Menubar() {
     console.log(history)
   },[])
 
+  const [Clatitude, setCLatitude] = useState()
+  const [Clongitude, setCLongitude] = useState()
+
+  navigator.geolocation.getCurrentPosition((position) => {
+    setCLatitude(position.coords.latitude);
+    setCLongitude(position.coords.longitude);
+  })
+
   return (
     <Wrap>
       <TopBtnWrapper>
@@ -89,7 +96,13 @@ function Menubar() {
         </TopBtn>
       </TopBtnWrapper>
       <TopMenu>
-        <Link to='/PLEA-STREET/mapSearch' style={{ color: 'black' }}>
+        <Link to={{
+            pathname: "/PLEA-STREET/mapSearch",
+            state: {
+              latitude: Clatitude,
+              longitude: Clongitude
+            }
+        }} style={{ color: 'black' }} >
           <MenuBtn>
             <span>위치검색</span>
           </MenuBtn>
@@ -99,7 +112,7 @@ function Menubar() {
             <span>검사</span>
           </MenuBtn>
         </Link>
-        <Link to='/PLEA-STREET/' style={{ color: 'black' }}>
+        <Link to='/PLEA-STREET/community' style={{ color: 'black' }}>
           <MenuBtn>
             <span>커뮤니티</span>
           </MenuBtn>

--- a/src/page/Landing.js
+++ b/src/page/Landing.js
@@ -76,7 +76,7 @@ function Landing(props) {
     const getLocation = (props) => {
         if (Clongitude >=1 && Clatitude >=1) {
             history.push({
-                pathname: "/PLEA-STREET/map",
+                pathname: "/PLEA-STREET/mapSearch",
                 state: {
                     latitude: Clatitude,
                     longitude : Clongitude


### PR DESCRIPTION
#### Menu bar에서 "지도 검색" 메뉴 눌렀을 때 오류 나는 버그 해결.

=> route 주소 변경 및 navigator.geolocation.getCurrentPosition()로 받아온 사용자 현재 위치 props 전달.